### PR TITLE
Fixes two bugs causing crashes when using multiple SharedHashMaps and Serializing integers greater than 256.

### DIFF
--- a/src/tanktrouble/Main.java
+++ b/src/tanktrouble/Main.java
@@ -24,7 +24,7 @@ public class Main {
         }else{
             TankTrouble.name = args[3];
         }
-        if(!TankTrouble.isHost) Thread.sleep(1000);
+        if(!TankTrouble.isHost) Thread.sleep(2000);
         TankTrouble.main("tanktrouble.game.client.TankTrouble", args);
     }
 }

--- a/src/tanktrouble/game/client/Bullet.java
+++ b/src/tanktrouble/game/client/Bullet.java
@@ -92,6 +92,7 @@ public class Bullet implements Serializable {
             out.writeFloat(angle);
         }
 
+        // Deserializer
         public UpdateBulletAction(SerializingInputStream in) throws SerializingInputStream.InvalidStreamLengthException {
             this.x = in.readFloat();
             this.y = in.readFloat();

--- a/src/tanktrouble/game/client/Game.java
+++ b/src/tanktrouble/game/client/Game.java
@@ -50,7 +50,6 @@ public class Game {
                 tanks = new SharedHashMapClient<>(actionManager, Synchronizers.STRING_SYNCHRONIZER, tankSynchronizer);
                 bullets = new SharedHashMapClient<>(actionManager, Synchronizers.INTEGER_SYNCHRONIZER, bulletSynchronizer);
                 tanks.registerElementAction(Tank.UpdateTankAction::new, Tank.UpdateTankAction.class);
-                tanks.registerElementAction(Tank.UpdateTankAction::new, Tank.UpdateTankAction.class);
                 bullets.registerElementAction(Bullet.UpdateBulletAction::new, Bullet.UpdateBulletAction.class);
                 sc.start();
             }catch (Exception e){

--- a/src/tanktrouble/game/client/TankTrouble.java
+++ b/src/tanktrouble/game/client/TankTrouble.java
@@ -20,6 +20,7 @@ public class TankTrouble extends PApplet {
     @Override
     public void setup() {
         super.setup();
+        surface.setTitle(isHost ? "TankTrouble Server" : "TankTrouble Client");
         frameRate(30);
     }
 
@@ -55,7 +56,7 @@ public class TankTrouble extends PApplet {
             if(isHost){
                 for(Map.Entry<Integer, Bullet> bulletEntry : game.bullets.entrySet()) {
                     bulletEntry.getValue().move();
-                    //game.bullets.sendAction(bulletEntry.getKey(), new Bullet.UpdateBulletAction(bulletEntry.getValue()));
+                    game.bullets.sendAction(bulletEntry.getKey(), new Bullet.UpdateBulletAction(bulletEntry.getValue()));
                 }
             }
             for(Map.Entry<Integer, Bullet> bulletEntry : game.bullets.entrySet()){

--- a/src/tanktrouble/game/client/util/actions/ActionManager.java
+++ b/src/tanktrouble/game/client/util/actions/ActionManager.java
@@ -15,7 +15,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class ActionManager {
     private final ArrayList<Deserializer<Action>> actions = new ArrayList<>();
-    private final HashMap<Class<?>, Integer> actionMap = new HashMap<>();
     private final NamedConnection connection;
 
     protected ReentrantLock lock = new ReentrantLock(); // TODO replace this with a better solution
@@ -25,9 +24,9 @@ public abstract class ActionManager {
         connection.setListener((data, source) -> processPacket(new SerializingInputStream(data), source));
     }
 
-    public void registerAction(Deserializer<Action> deserializer, Class<?> type){
-        actionMap.put(type, actions.size());
+    public int registerAction(Deserializer<Action> deserializer, Class<?> type){
         actions.add(deserializer);
+        return actions.size() - 1;
     }
 
     public void lock(){
@@ -43,7 +42,8 @@ public abstract class ActionManager {
         int type = in.readInt();
         switch (type) {
             case 0:
-                processActionRequest(unpackageAction(in), source);
+                int actionID = in.readInt();
+                processActionRequest(unpackageAction(in, actionID), actionID, source);
                 break;
             case 1:
                 processActionAcknowledgement(new ActionAcknowledgement(in), source);
@@ -55,10 +55,10 @@ public abstract class ActionManager {
         lock.unlock();
     }
 
-    protected void emitAction(Action action, Destination destination) throws IOException {
+    protected void emitAction(Action action, int actionID, Destination destination) throws IOException {
         SerializingOutputStream out = new SerializingOutputStream();
         out.writeInt(0);
-        packageAction(out, action);
+        packageAction(out, action, actionID);
         connection.send(out.toByteArray(), destination);
     }
 
@@ -75,11 +75,11 @@ public abstract class ActionManager {
         connection.send(out.toByteArray(), destination);
     }
 
-    public abstract boolean sendActionRequest(Action action) throws IOException;
+    public abstract boolean sendActionRequest(Action action, int actionID) throws IOException;
 
     protected abstract void processRollbackAcknowledgement(Source source);
 
-    protected abstract void processActionRequest(Action action, Source source);
+    protected abstract void processActionRequest(Action action, int actionID, Source source);
 
     protected abstract void processActionAcknowledgement(ActionAcknowledgement actionAcknowledgement, Source source);
 
@@ -100,17 +100,12 @@ public abstract class ActionManager {
         }
     }
 
-    private void packageAction(SerializingOutputStream out, Action action){
-        Integer actionID = actionMap.get(action.getClass());
-        if(actionID == null){
-            throw new RuntimeException("Unregistered action: " + action.getClass().getName());
-        }
+    private void packageAction(SerializingOutputStream out, Action action, int actionID){
         out.writeInt(actionID);
         action.serialize(out);
     }
 
-    private Action unpackageAction(SerializingInputStream in) throws SerializingInputStream.InvalidStreamLengthException {
-        int actionID = in.readInt();
+    private Action unpackageAction(SerializingInputStream in, int actionID) throws SerializingInputStream.InvalidStreamLengthException {
         return actions.get(actionID).deserialize(in);
     }
 }

--- a/src/tanktrouble/game/client/util/actions/ActionManager.java
+++ b/src/tanktrouble/game/client/util/actions/ActionManager.java
@@ -24,7 +24,7 @@ public abstract class ActionManager {
         connection.setListener((data, source) -> processPacket(new SerializingInputStream(data), source));
     }
 
-    public int registerAction(Deserializer<Action> deserializer, Class<?> type){
+    public int registerAction(Deserializer<Action> deserializer){
         actions.add(deserializer);
         return actions.size() - 1;
     }

--- a/src/tanktrouble/game/client/util/actions/ActionManagerClient.java
+++ b/src/tanktrouble/game/client/util/actions/ActionManagerClient.java
@@ -24,13 +24,13 @@ public class ActionManagerClient extends ActionManager {
     }
 
     @Override
-    public boolean sendActionRequest(Action action) {
+    public boolean sendActionRequest(Action action, int actionID) {
         if(validDeadReckonState){
             boolean result = action.apply();
             if(result) {
                 acknowledgementBuffer.push(action);
                 try {
-                    emitAction(action, new Destination(Destination.Policy.ALL));
+                    emitAction(action, actionID, new Destination(Destination.Policy.ALL));
                 }catch (Exception e){
                     e.printStackTrace();
                     acknowledgementBuffer.pop();
@@ -49,7 +49,7 @@ public class ActionManagerClient extends ActionManager {
     }
 
     @Override
-    public void processActionRequest(Action action, Source source) {
+    public void processActionRequest(Action action, int actionID, Source source) {
         if(!acknowledgementBuffer.isEmpty()) {
             preAcknowledgementFutureBuffer.push(action);
         }else{

--- a/src/tanktrouble/game/client/util/actions/ActionManagerServer.java
+++ b/src/tanktrouble/game/client/util/actions/ActionManagerServer.java
@@ -16,10 +16,10 @@ public class ActionManagerServer extends ActionManager {
     }
 
     @Override
-    public boolean sendActionRequest(Action action) throws IOException {
+    public boolean sendActionRequest(Action action, int actionID) throws IOException {
         boolean result = action.apply();
         if(result){
-            emitAction(action, new Destination(Destination.Policy.ALL));
+            emitAction(action, actionID, new Destination(Destination.Policy.ALL));
         }
         return result;
     }
@@ -30,7 +30,7 @@ public class ActionManagerServer extends ActionManager {
     }
 
     @Override
-    public void processActionRequest(Action action, Source source) {
+    public void processActionRequest(Action action, int actionID, Source source) {
         boolean accept;
         if(!stateValid.containsKey(source)){
             stateValid.put(source, true);
@@ -42,7 +42,7 @@ public class ActionManagerServer extends ActionManager {
             boolean result = action.apply();
             if (result) {
                 try {
-                    emitAction(action, new Destination(Destination.Policy.ALL_EXCEPT, source));
+                    emitAction(action, actionID, new Destination(Destination.Policy.ALL_EXCEPT, source));
                 }catch (Exception e){
                     e.printStackTrace();
                 }

--- a/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMap.java
+++ b/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMap.java
@@ -38,11 +38,11 @@ public abstract class SharedHashMap<K, V> {
     protected int elementActionHandle;
 
     private void registerCollectionActions(){
-        syncRequestHandle = actionManager.registerAction(SyncRequest::new, SyncRequest.class);
-        syncDataHandle = actionManager.registerAction(SyncData::new, SyncData.class);
-        putActionHandle = actionManager.registerAction(PutAction::new, PutAction.class);
-        removeActionHandle = actionManager.registerAction(RemoveAction::new, RemoveAction.class);
-        elementActionHandle = actionManager.registerAction(ElementAction::new, ElementAction.class);
+        syncRequestHandle = actionManager.registerAction(SyncRequest::new);
+        syncDataHandle = actionManager.registerAction(SyncData::new);
+        putActionHandle = actionManager.registerAction(PutAction::new);
+        removeActionHandle = actionManager.registerAction(RemoveAction::new);
+        elementActionHandle = actionManager.registerAction(ElementAction::new);
     }
 
     private final ArrayList<Deserializer<TargetedAction<V>>> elementActions = new ArrayList<>();

--- a/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMapClient.java
+++ b/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMapClient.java
@@ -8,7 +8,7 @@ public class SharedHashMapClient<K, V> extends SharedHashMap<K, V> {
     public SharedHashMapClient(ActionManager actionManager, Synchronizer<K> keySynchronizer, Synchronizer<V> valueSynchronizer) {
         super(actionManager, keySynchronizer, valueSynchronizer);
         try {
-            actionManager.sendActionRequest(new SyncRequest());
+            actionManager.sendActionRequest(new SyncRequest(), syncRequestHandle);
         }catch (Exception e){
             e.printStackTrace();
         }

--- a/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMapServer.java
+++ b/src/tanktrouble/game/client/util/sharedhashmap/SharedHashMapServer.java
@@ -13,7 +13,7 @@ public class SharedHashMapServer<K, V> extends SharedHashMap<K, V> {
     protected void applySyncRequest(SyncRequest syncRequest) {
         SyncData syncData = new SyncData();
         try {
-            actionManager.sendActionRequest(syncData);
+            actionManager.sendActionRequest(syncData, syncDataHandle);
         }catch (Exception e){
             e.printStackTrace();
         }

--- a/src/tanktrouble/generated/util/serial/SerializingOutputStream.java
+++ b/src/tanktrouble/generated/util/serial/SerializingOutputStream.java
@@ -17,7 +17,7 @@ public class SerializingOutputStream extends ByteArrayOutputStream {
 
         for(int i = 4; i != 0; i--) {
             buf[i-1] = (byte) (val & 0xFF);
-            val <<= 8;
+            val >>= 8;
         }
         try {
             write(buf);
@@ -31,7 +31,7 @@ public class SerializingOutputStream extends ByteArrayOutputStream {
 
         for(int i = 8; i != 0; i--) {
             buf[i-1] = (byte) (val & 0xFF);
-            val <<= 8;
+            val >>= 8;
         }
         try {
             write(buf);


### PR DESCRIPTION
* `SharedHashMap` bug 
   * removed `Class<?>` parameter from `ActionManager.registerAction()` 
   * added `actionID` return to `ActionManager.registerAction()` 
   * updated associated code
* Serializing integers bug
   * changed shift direction in `SerializingOutputStream.writeInt()` and `SerializingOutputStream.writeLong()`
* increased client sleep time on startup in main for simultaneous launch